### PR TITLE
[Feature] Popover when setting Link

### DIFF
--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -180,13 +180,19 @@ const InsertLinkForm = ({ onInsert, displayText = "", previousUrl = "" }: Insert
 const Toolbar = ({ editor }: { editor: Editor }) => {
   const setLink = useCallback(
     (url: string, displayText: string) => {
+      const { from, to } = editor.view.state.selection;
       // empty
       if (url === "") {
-        editor.chain().focus().extendMarkRange("link").unsetLink().run();
+        editor
+          .chain()
+          .focus()
+          .extendMarkRange("link")
+          .unsetLink()
+          .insertContentAt({ from, to }, displayText)
+          .run();
 
         return;
       }
-      const { from, to } = editor.view.state.selection;
 
       // No text was previously selected, so add new text
       if (from === to) {

--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -181,6 +181,9 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
   const setLink = useCallback(
     (url: string, displayText: string) => {
       const { from, to } = editor.view.state.selection;
+      /**
+       * @todo Fix bug where a highlight contains both a link, and non-linked text
+       */
       // empty
       if (url === "") {
         editor

--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -192,13 +192,6 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
   const setLink = useCallback(
     (url: string, displayText: string) => {
       const { from, to } = editor.view.state.selection;
-      /**
-       * @todo Fix bug where an existing link that is either partially
-       * highlighted, or the cursor is in the middle of the linked text, only
-       * has the URL populated in the Popover, but not the displayText
-       *
-       * The editor will also need to select this text
-       */
       // empty
       if (url === "") {
         editor

--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -255,11 +255,26 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
         </Toggle>
       </Tooltip>
 
-      <Tooltip content="Hyperlink">
-        <Button type="button" size="sm" variant="ghost" className="px-2" onClick={setLink}>
-          <LinkSimple />
-        </Button>
-      </Tooltip>
+      <Popover>
+        <Tooltip content="Hyperlink">
+          <PopoverTrigger asChild>
+            <Button type="button" size="sm" variant="ghost" className="px-2">
+              <LinkSimple />
+            </Button>
+          </PopoverTrigger>
+        </Tooltip>
+        <PopoverContent className="w-80">
+          <InsertLinkForm
+            onInsert={() => {}}
+            displayText={editor.state.doc.textBetween(
+              editor.view.state.selection.from,
+              editor.view.state.selection.to,
+              " ",
+            )}
+            previousUrl={editor.getAttributes("link").href}
+          />
+        </PopoverContent>
+      </Popover>
 
       <Tooltip content="Inline Code">
         <Toggle

--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -201,9 +201,11 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           })
           .run();
       } else {
+        // Text was selected, so replace the selected text with the displayText input
         editor
           .chain()
-          .setTextSelection({ from, to })
+          .insertContentAt({ from, to }, displayText)
+          .setTextSelection({ from, to: displayText.length + 1 })
           .extendMarkRange("link")
           .setLink({ href: url })
           .focus()

--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -126,6 +126,20 @@ type InsertLinkProps = {
   previousUrl?: string;
 };
 
+const InsertLinkForm = ({ onInsert, displayText = "", previousUrl = "" }: InsertLinkProps) => {
+  const form = useForm<InsertLinkFormValues>({
+    resolver: zodResolver(InsertLinkFormSchema),
+    defaultValues: { url: previousUrl, displayText },
+  });
+
+  const onSubmit = (values: InsertLinkFormValues) => {
+    onInsert(values);
+    form.reset();
+  };
+
+  return null;
+};
+
 const Toolbar = ({ editor }: { editor: Editor }) => {
   const setLink = useCallback(() => {
     const previousUrl = editor.getAttributes("link").href;

--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -214,7 +214,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
         editor
           .chain()
           .insertContentAt({ from, to }, displayText)
-          .setTextSelection({ from, to: displayText.length + 1 })
+          .setTextSelection({ from, to: from + displayText.length })
           .extendMarkRange("link")
           .setLink({ href: url })
           .focus()

--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -122,11 +122,21 @@ type InsertLinkFormValues = z.infer<typeof InsertLinkFormSchema>;
 
 type InsertLinkProps = {
   onInsert: (value: InsertLinkFormValues) => void;
-  displayText?: string;
-  previousUrl?: string;
+  editor: Editor;
 };
 
-const InsertLinkForm = ({ onInsert, displayText = "", previousUrl = "" }: InsertLinkProps) => {
+const InsertLinkForm = ({ onInsert, editor }: InsertLinkProps) => {
+  const previousUrl = editor.getAttributes("link").href;
+  if (previousUrl) {
+    // If the current selection contains a link, then select the whole text
+    // to ensure the full displayText associated with the link is editable
+    editor.commands.extendMarkRange("link");
+  }
+  const displayText = editor.state.doc.textBetween(
+    editor.view.state.selection.from,
+    editor.view.state.selection.to,
+    " ",
+  );
   const form = useForm<InsertLinkFormValues>({
     resolver: zodResolver(InsertLinkFormSchema),
     // Defaulting to "https://" to save the user from having to type it
@@ -300,12 +310,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
               const { url, displayText } = props;
               setLink(url, displayText);
             }}
-            displayText={editor.state.doc.textBetween(
-              editor.view.state.selection.from,
-              editor.view.state.selection.to,
-              " ",
-            )}
-            previousUrl={editor.getAttributes("link").href}
+            editor={editor}
           />
         </PopoverContent>
       </Popover>

--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -137,7 +137,44 @@ const InsertLinkForm = ({ onInsert, displayText = "", previousUrl = "" }: Insert
     form.reset();
   };
 
-  return null;
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
+        <FormField
+          name="url"
+          control={form.control}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>URL</FormLabel>
+              <FormControl>
+                <Input placeholder="http://..." {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          name="displayText"
+          control={form.control}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Display Text</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <div className="!mt-5 ml-auto max-w-fit">
+          <Button type="submit" variant="secondary" size="sm">
+            Insert Link
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
 };
 
 const Toolbar = ({ editor }: { editor: Editor }) => {

--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -180,9 +180,6 @@ const InsertLinkForm = ({ onInsert, displayText = "", previousUrl = "" }: Insert
 const Toolbar = ({ editor }: { editor: Editor }) => {
   const setLink = useCallback(
     (url: string, displayText: string) => {
-      /**
-       * @todo Implementation incomplete, need to continue to revise
-       */
       // empty
       if (url === "") {
         editor.chain().focus().extendMarkRange("link").unsetLink().run();
@@ -209,6 +206,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           .setTextSelection({ from, to })
           .extendMarkRange("link")
           .setLink({ href: url })
+          .focus()
           .run();
       }
     },

--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -113,6 +113,19 @@ const InsertImageForm = ({ onInsert }: InsertImageProps) => {
   );
 };
 
+const InsertLinkFormSchema = z.object({
+  url: z.string(),
+  displayText: z.string(),
+});
+
+type InsertLinkFormValues = z.infer<typeof InsertLinkFormSchema>;
+
+type InsertLinkProps = {
+  onInsert: (value: InsertLinkFormValues) => void;
+  displayText?: string;
+  previousUrl?: string;
+};
+
 const Toolbar = ({ editor }: { editor: Editor }) => {
   const setLink = useCallback(() => {
     const previousUrl = editor.getAttributes("link").href;

--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -129,7 +129,8 @@ type InsertLinkProps = {
 const InsertLinkForm = ({ onInsert, displayText = "", previousUrl = "" }: InsertLinkProps) => {
   const form = useForm<InsertLinkFormValues>({
     resolver: zodResolver(InsertLinkFormSchema),
-    defaultValues: { url: previousUrl, displayText },
+    // Defaulting to "https://" to save the user from having to type it
+    defaultValues: { url: previousUrl || "https://", displayText },
   });
 
   const onSubmit = (values: InsertLinkFormValues) => {

--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -183,7 +183,11 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
     (url: string, displayText: string) => {
       const { from, to } = editor.view.state.selection;
       /**
-       * @todo Fix bug where a highlight contains both a link, and non-linked text
+       * @todo Fix bug where an existing link that is either partially
+       * highlighted, or the cursor is in the middle of the linked text, only
+       * has the URL populated in the Popover, but not the displayText
+       *
+       * The editor will also need to select this text
        */
       // empty
       if (url === "") {


### PR DESCRIPTION
As a small personal coding challenge, I expanded upon the idea suggested here:

https://github.com/AmruthPillai/Reactive-Resume/pull/1727#issuecomment-1902713510

This PR replaces the `window.prompt` for adding/editing a link in the Text Editor with a `Popover` component

https://github.com/CorreyL/Reactive-Resume/assets/16601729/b3e7c8fe-0bd9-4384-a7fb-e3b82b9b650d

The details in this PR will be expanded upon if the Reactive Resume maintainers have any interest in this feature being added to the main codebase.
